### PR TITLE
Add SDK Version Header

### DIFF
--- a/apiclient.go
+++ b/apiclient.go
@@ -227,5 +227,9 @@ func (c *ApiClient) request(method, urlStr string, body *[]byte) (*http.Response
 	}
 	res, err := client.Do(req)
 
+	if res.StatusCode == 401 {
+		return res, fmt.Errorf("Unauthorized")
+	}
+
 	return res, err
 }

--- a/apiclient.go
+++ b/apiclient.go
@@ -27,8 +27,10 @@ func NewApiClient(path string, apiKey ...string) ApiClient {
 		apiClient.apiKey = apiKey[0]
 	}
 
+	// When the version gets bumped, ensure the version string is bumped as well
 	apiClient.requestHeaders = map[string]interface{}{
-		"User-Agent": "OpenAPI-Generator/1.0/go",
+		"User-Agent":           "OpenAPI-Generator/1.0/go",
+		"X-Adzerk-Sdk-Version": "linksports-decision-sdk-go:v0.0.1-alpha.1",
 	}
 
 	return apiClient


### PR DESCRIPTION
Kevel keeps track of requests coming from various SDKs using a custom header on the request. This helps debug issues as they come in from end-users.

This PR adds the custom header for requests coming from the Go SDK.