### PR TITLE
Add APIs to add / remove user's interests

### DIFF
--- a/apiclient.go
+++ b/apiclient.go
@@ -120,7 +120,7 @@ func (c *ApiClient) AddInterests(networkId int, userKey string, interests []stri
 	return err
 }
 
-func (c *ApiClient) RemoveMultipleInterests(networkId int, userKey string, interests []string) error {
+func (c *ApiClient) RemoveInterests(networkId int, userKey string, interests []string) error {
 	values := url.Values{
 		"userKey": {userKey},
 	}

--- a/apiclient.go
+++ b/apiclient.go
@@ -93,6 +93,7 @@ func (c *ApiClient) SetCustomProperties(networkId int, userKey string, props map
 	}
 	urlStr := fmt.Sprintf("%s/%d/custom?%s", c.basePath, networkId, values.Encode())
 	body, _ := json.Marshal(props)
+	c.requestHeaders["Accept"] = "text/plain"
 	c.requestHeaders["Content-Type"] = "application/json"
 	_, err := c.request("POST", urlStr, &body)
 	return err
@@ -104,6 +105,7 @@ func (c *ApiClient) AddInterest(networkId int, userKey string, interest string) 
 		"interest": {interest},
 	}
 	urlStr := fmt.Sprintf("%s/%d/interest/i.gif?%s", c.basePath, networkId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("GET", urlStr, nil)
 	return err
 }
@@ -139,6 +141,7 @@ func (c *ApiClient) AddRetargetingSegment(networkId int, userKey string, adverti
 	urlStr := fmt.Sprintf(
 		"%s/%d/rt/%d/%d/i.gif?%s",
 		c.basePath, networkId, advertiserId, retargetingSegmentId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("GET", urlStr, nil)
 	return err
 }
@@ -148,6 +151,7 @@ func (c *ApiClient) Forget(networkId int, userKey string) error {
 		"userKey": {userKey},
 	}
 	urlStr := fmt.Sprintf("%s/%d?%s", c.basePath, networkId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("DELETE", urlStr, nil)
 	return err
 }
@@ -155,6 +159,7 @@ func (c *ApiClient) Forget(networkId int, userKey string) error {
 func (c *ApiClient) GdprConsent(networkId int, consentRequest model.ConsentRequest) error {
 	urlStr := fmt.Sprintf("%s/%d/consent", c.basePath, networkId)
 	body, _ := json.Marshal(consentRequest)
+	c.requestHeaders["Accept"] = "text/plain"
 	c.requestHeaders["Content-Type"] = "application/json"
 	_, err := c.request("POST", urlStr, &body)
 	return err
@@ -166,6 +171,7 @@ func (c *ApiClient) IpOverride(networkId int, userKey, ip string) error {
 		"ip":      {ip},
 	}
 	urlStr := fmt.Sprintf("%s/%d/ip/i.gif?%s", c.basePath, networkId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("GET", urlStr, nil)
 	return err
 }
@@ -177,6 +183,7 @@ func (c *ApiClient) MatchUser(networkId int, userKey string, partnerId, userId i
 		"userId":    {strconv.Itoa(userId)},
 	}
 	urlStr := fmt.Sprintf("%s/%d/sync/i.gif?%s", c.basePath, networkId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("GET", urlStr, nil)
 	return err
 }
@@ -186,6 +193,7 @@ func (c *ApiClient) OptOut(networkId int, userKey string) error {
 		"userKey": {userKey},
 	}
 	urlStr := fmt.Sprintf("%s/%d/optout/i.gif?%s", c.basePath, networkId, values.Encode())
+	c.requestHeaders["Accept"] = "text/plain"
 	_, err := c.request("GET", urlStr, nil)
 	return err
 }
@@ -195,7 +203,7 @@ func (c *ApiClient) ReadUser(networkId int, userKey string) (model.UserRecord, e
 		"userKey": {userKey},
 	}
 	urlStr := fmt.Sprintf("%s/%d/read?%s", c.basePath, networkId, values.Encode())
-
+	c.requestHeaders["Accept"] = "application/json"
 	res, err := c.request("GET", urlStr, nil)
 
 	if err != nil {

--- a/apiclient.go
+++ b/apiclient.go
@@ -108,6 +108,30 @@ func (c *ApiClient) AddInterest(networkId int, userKey string, interest string) 
 	return err
 }
 
+func (c *ApiClient) AddMultipleInterests(networkId int, userKey string, interests []string) error {
+	values := url.Values{
+		"userKey": {userKey},
+	}
+	urlStr := fmt.Sprintf("%s/%d/interests?%s", c.basePath, networkId, values.Encode())
+	body, _ := json.Marshal(interests)
+	c.requestHeaders["Accept"] = "text/plain"
+	c.requestHeaders["Content-Type"] = "application/json"
+	_, err := c.request("POST", urlStr, &body)
+	return err
+}
+
+func (c *ApiClient) RemoveMultipleInterests(networkId int, userKey string, interests []string) error {
+	values := url.Values{
+		"userKey": {userKey},
+	}
+	urlStr := fmt.Sprintf("%s/%d/interests?%s", c.basePath, networkId, values.Encode())
+	body, _ := json.Marshal(interests)
+	c.requestHeaders["Accept"] = "text/plain"
+	c.requestHeaders["Content-Type"] = "application/json"
+	_, err := c.request("DELETE", urlStr, &body)
+	return err
+}
+
 func (c *ApiClient) AddRetargetingSegment(networkId int, userKey string, advertiserId, retargetingSegmentId int) error {
 	values := url.Values{
 		"userKey": {userKey},

--- a/apiclient.go
+++ b/apiclient.go
@@ -108,7 +108,7 @@ func (c *ApiClient) AddInterest(networkId int, userKey string, interest string) 
 	return err
 }
 
-func (c *ApiClient) AddMultipleInterests(networkId int, userKey string, interests []string) error {
+func (c *ApiClient) AddInterests(networkId int, userKey string, interests []string) error {
 	values := url.Values{
 		"userKey": {userKey},
 	}

--- a/userdbclient.go
+++ b/userdbclient.go
@@ -26,8 +26,8 @@ func (c *UserDbClient) AddInterests(userKey string, interests []string, networkI
 	return c.apiClient.AddInterests(c.NetworkId(networkIds...), userKey, interests)
 }
 
-func (c *UserDbClient) RemoveMultipleInterests(userKey string, interests []string, networkIds ...int) error {
-	return c.apiClient.RemoveMultipleInterests(c.NetworkId(networkIds...), userKey, interests)
+func (c *UserDbClient) RemoveInterests(userKey string, interests []string, networkIds ...int) error {
+	return c.apiClient.RemoveInterests(c.NetworkId(networkIds...), userKey, interests)
 }
 
 func (c *UserDbClient) AddRetargetingSegment(userKey string, advertiserId, retargetingSegmentId int, networkIds ...int) error {

--- a/userdbclient.go
+++ b/userdbclient.go
@@ -22,6 +22,14 @@ func (c *UserDbClient) AddInterest(userKey string, interest string, networkIds .
 	return c.apiClient.AddInterest(c.NetworkId(networkIds...), userKey, interest)
 }
 
+func (c *UserDbClient) AddMultipleInterests(userKey string, interests []string, networkIds ...int) error {
+	return c.apiClient.AddMultipleInterests(c.NetworkId(networkIds...), userKey, interests)
+}
+
+func (c *UserDbClient) RemoveMultipleInterests(userKey string, interests []string, networkIds ...int) error {
+	return c.apiClient.RemoveMultipleInterests(c.NetworkId(networkIds...), userKey, interests)
+}
+
 func (c *UserDbClient) AddRetargetingSegment(userKey string, advertiserId, retargetingSegmentId int, networkIds ...int) error {
 	return c.apiClient.AddRetargetingSegment(c.NetworkId(networkIds...), userKey, advertiserId, retargetingSegmentId)
 }

--- a/userdbclient.go
+++ b/userdbclient.go
@@ -22,8 +22,8 @@ func (c *UserDbClient) AddInterest(userKey string, interest string, networkIds .
 	return c.apiClient.AddInterest(c.NetworkId(networkIds...), userKey, interest)
 }
 
-func (c *UserDbClient) AddMultipleInterests(userKey string, interests []string, networkIds ...int) error {
-	return c.apiClient.AddMultipleInterests(c.NetworkId(networkIds...), userKey, interests)
+func (c *UserDbClient) AddInterests(userKey string, interests []string, networkIds ...int) error {
+	return c.apiClient.AddInterests(c.NetworkId(networkIds...), userKey, interests)
 }
 
 func (c *UserDbClient) RemoveMultipleInterests(userKey string, interests []string, networkIds ...int) error {


### PR DESCRIPTION
Adding new APIs to manage multiple interests.

https://dev.kevel.com/reference/add-interests

```go
interests := []string{"Sports", "Basketball"}
userDB.AddMultipleInterests(userKey, interests)
```

https://dev.kevel.com/reference/remove-multiple-interests

```go
interests := []string{"Sports", "Basketball"}
userDB.RemoveMultipleInterests(userKey, interests)
```